### PR TITLE
Implement basic persistence for character attributes

### DIFF
--- a/silkroad-agent/conf/default.toml
+++ b/silkroad-agent/conf/default.toml
@@ -14,6 +14,7 @@ desired-ticks = 128
 client-timeout = 30
 deletion-time = 10080
 max-follow-distance = 300.0
+auto-save-interval = 30
 
 [game.spawner]
 radius = 500

--- a/silkroad-agent/src/comp/mod.rs
+++ b/silkroad-agent/src/comp/mod.rs
@@ -25,13 +25,20 @@ pub(crate) struct GameEntity {
 #[derive(Component)]
 pub(crate) struct Playing(pub(crate) ServerUser, pub(crate) PlayingToken);
 
-#[derive(Component)]
+#[derive(Component, Copy, Clone)]
 pub(crate) struct Health {
     pub current_health: u32,
     pub max_health: u32,
 }
 
 impl Health {
+    pub fn new_with_current(current: u32, max: u32) -> Self {
+        Self {
+            current_health: current,
+            max_health: max,
+        }
+    }
+
     pub fn new(max_health: u32) -> Self {
         Self {
             current_health: max_health,

--- a/silkroad-agent/src/comp/mod.rs
+++ b/silkroad-agent/src/comp/mod.rs
@@ -60,6 +60,26 @@ impl Health {
     }
 }
 
+#[derive(Component, Copy, Clone)]
+pub struct Mana {
+    pub current_mana: u32,
+    pub max_mana: u32,
+}
+
+impl Mana {
+    pub fn new_with_current(current: u32, max: u32) -> Mana {
+        Self {
+            current_mana: current,
+            max_mana: max,
+        }
+    }
+
+    pub fn upgrade(&mut self, new_max: u32) {
+        self.max_mana = new_max;
+        self.current_mana = new_max;
+    }
+}
+
 #[derive(Hash, Copy, Clone, Eq, PartialEq)]
 pub struct EntityReference(pub Entity, pub(crate) GameEntity);
 

--- a/silkroad-agent/src/comp/player.rs
+++ b/silkroad-agent/src/comp/player.rs
@@ -5,7 +5,7 @@ use crate::comp::inventory::PlayerInventory;
 use crate::comp::pos::Position;
 use crate::comp::sync::Synchronize;
 use crate::comp::visibility::Visibility;
-use crate::comp::{GameEntity, Health};
+use crate::comp::{GameEntity, Health, Mana};
 use crate::db::character::CharacterData;
 use crate::db::user::ServerUser;
 use crate::input::PlayerInput;
@@ -67,6 +67,7 @@ pub(crate) struct PlayerBundle {
     pub speed: MovementState,
     pub damage_receiver: DamageReceiver,
     pub health: Health,
+    pub mana: Mana,
 }
 
 impl PlayerBundle {
@@ -81,6 +82,7 @@ impl PlayerBundle {
     ) -> Self {
         let player = Player::from_db_data(server_user, &character);
         let max_hp = player.character.max_hp();
+        let max_mp = player.character.max_mp();
         Self {
             player,
             game_entity,
@@ -95,6 +97,7 @@ impl PlayerBundle {
             speed: MovementState::default_player(),
             damage_receiver: DamageReceiver::default(),
             health: Health::new_with_current(character.current_hp as u32, max_hp),
+            mana: Mana::new_with_current(character.current_mp as u32, max_mp),
         }
     }
 }

--- a/silkroad-agent/src/comp/pos.rs
+++ b/silkroad-agent/src/comp/pos.rs
@@ -3,7 +3,7 @@ use cgmath::{MetricSpace, Vector2};
 use silkroad_game_base::{GlobalPosition, Heading};
 use silkroad_protocol::world::{EntityMovementState, MovementType};
 
-#[derive(Component, Clone)]
+#[derive(Component, Clone, Copy)]
 pub(crate) struct Position {
     pub location: GlobalPosition,
     pub rotation: Heading,

--- a/silkroad-agent/src/comp/sync.rs
+++ b/silkroad-agent/src/comp/sync.rs
@@ -10,6 +10,7 @@ pub struct Synchronize {
     pub state: Vec<UpdatedState>,
     pub actions: Vec<ActionAnimation>,
     pub health: Option<u32>,
+    pub mana: Option<u32>,
     pub did_level: bool,
 }
 

--- a/silkroad-agent/src/config.rs
+++ b/silkroad-agent/src/config.rs
@@ -50,6 +50,7 @@ pub(crate) struct GameConfig {
     pub(crate) deletion_time: u32,
     pub(crate) spawner: SpawnOptions,
     pub(crate) max_follow_distance: f32,
+    pub(crate) auto_save_interval: u32,
 }
 
 #[derive(Deserialize, Default, Clone)]

--- a/silkroad-agent/src/db/character.rs
+++ b/silkroad-agent/src/db/character.rs
@@ -1,6 +1,6 @@
 use crate::comp::player::Player;
 use crate::comp::pos::Position;
-use crate::comp::Health;
+use crate::comp::{Health, Mana};
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use sqlx::{Error, PgPool};
@@ -78,6 +78,7 @@ impl CharacterData {
     pub(crate) async fn update_character_info<T: Borrow<PgPool>>(
         player: Player,
         health: Health,
+        mana: Mana,
         pos: Position,
         pool: T,
     ) {

--- a/silkroad-agent/src/login/charselect.rs
+++ b/silkroad-agent/src/login/charselect.rs
@@ -1,7 +1,7 @@
 use crate::agent::Agent;
 use crate::comp::inventory::PlayerInventory;
 use crate::comp::net::Client;
-use crate::comp::player::{Player, PlayerBundle};
+use crate::comp::player::PlayerBundle;
 use crate::comp::pos::Position;
 use crate::comp::visibility::Visibility;
 use crate::comp::{GameEntity, Playing};
@@ -167,22 +167,8 @@ pub(crate) fn handle_join(
                         continue;
                     }
 
-                    let mut player = Player::from_db_data(playing.0.clone(), &character.character_data);
                     let inventory =
                         PlayerInventory::from_db(&character.items, 45, character.character_data.gold as u64);
-
-                    player.character.masteries = character
-                        .masteries
-                        .iter()
-                        .map(|mastery| {
-                            (
-                                WorldData::masteries()
-                                    .find_id(mastery.mastery_id as u32)
-                                    .expect("Mastery should exist"),
-                                mastery.level as u8,
-                            )
-                        })
-                        .collect::<Vec<_>>();
 
                     let data = &character.character_data;
 
@@ -201,19 +187,33 @@ pub(crate) fn handle_join(
 
                     client.send(CharacterJoinResponse::success());
 
-                    send_spawn(client, &game_entity, &player, &inventory, &position, settings.max_level);
+                    let mut bundle = PlayerBundle::new(
+                        playing.0.clone(),
+                        &character.character_data,
+                        game_entity,
+                        inventory,
+                        agent,
+                        position.clone(),
+                        Visibility::with_radius(500.),
+                    );
+                    bundle.player.character.masteries = character
+                        .masteries
+                        .iter()
+                        .map(|mastery| {
+                            (
+                                WorldData::masteries()
+                                    .find_id(mastery.mastery_id as u32)
+                                    .expect("Mastery should exist"),
+                                mastery.level as u8,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    send_spawn(client, &bundle, settings.max_level);
 
                     client.send(MacroStatus::Possible(MACRO_POTION | MACRO_HUNT | MACRO_SKILL, 0));
 
                     cmd.entity(entity)
-                        .insert(PlayerBundle::new(
-                            player,
-                            game_entity,
-                            inventory,
-                            agent,
-                            position.clone(),
-                            Visibility::with_radius(500.),
-                        ))
+                        .insert(bundle)
                         .remove::<CharacterSelect>()
                         .remove::<LoginInput>();
                 },
@@ -289,17 +289,14 @@ fn send_job_spread(client: &Client, hunters: u8, thieves: u8) {
     ));
 }
 
-fn send_spawn(
-    client: &Client,
-    entity: &GameEntity,
-    player: &Player,
-    inventory: &PlayerInventory,
-    position: &Position,
-    max_level: u8,
-) {
+fn send_spawn(client: &Client, bundle: &PlayerBundle, max_level: u8) {
     client.send(CharacterSpawnStart);
 
-    let character_data = &player.character;
+    let character_data = &bundle.player.character;
+    let position = &bundle.pos;
+    let inventory = &bundle.inventory;
+    let entity = &bundle.game_entity;
+    let health = &bundle.health;
 
     let entity_state = EntityState {
         alive: AliveState::Spawning,
@@ -344,8 +341,8 @@ fn send_spawn(
         character_data.sp,
         character_data.stat_points,
         character_data.berserk_points,
-        character_data.current_hp,
-        character_data.current_mp,
+        health.current_health,
+        character_data.stats.max_mana(character_data.level),
         character_data.beginner_mark,
         0,
         0,
@@ -360,8 +357,7 @@ fn send_spawn(
         inventory_items,
         5,
         Vec::new(),
-        player
-            .character
+        character_data
             .masteries
             .iter()
             .map(|(mastery, level)| MasteryData {
@@ -388,7 +384,7 @@ fn send_spawn(
         false,
         0,
         0xFF,
-        player.user.id as u32,
+        bundle.player.user.id as u32,
         character_data.gm,
         Vec::new(),
         0,

--- a/silkroad-agent/src/login/charselect.rs
+++ b/silkroad-agent/src/login/charselect.rs
@@ -297,6 +297,7 @@ fn send_spawn(client: &Client, bundle: &PlayerBundle, max_level: u8) {
     let inventory = &bundle.inventory;
     let entity = &bundle.game_entity;
     let health = &bundle.health;
+    let mana = &bundle.mana;
 
     let entity_state = EntityState {
         alive: AliveState::Spawning,
@@ -342,7 +343,7 @@ fn send_spawn(client: &Client, bundle: &PlayerBundle, max_level: u8) {
         character_data.stat_points,
         character_data.berserk_points,
         health.current_health,
-        character_data.stats.max_mana(character_data.level),
+        mana.current_mana,
         character_data.beginner_mark,
         0,
         0,

--- a/silkroad-agent/src/main.rs
+++ b/silkroad-agent/src/main.rs
@@ -10,6 +10,7 @@ mod input;
 mod login;
 mod mall;
 mod net;
+mod persist;
 mod population;
 mod server_plugin;
 mod tasks;
@@ -24,6 +25,7 @@ use crate::input::ReceivePlugin;
 use crate::login::LoginPlugin;
 use crate::mall::MallPlugin;
 use crate::net::NetworkPlugin;
+use crate::persist::PersistencePlugin;
 use crate::population::{CapacityController, LoginQueue};
 use crate::server_plugin::ServerPlugin;
 use crate::tasks::TaskCreator;
@@ -105,6 +107,7 @@ fn main() {
         .add_plugin(TimePlugin)
         .add_plugin(ReceivePlugin)
         .add_plugin(AgentPlugin)
+        .add_plugin(PersistencePlugin)
         .insert_resource::<DbPool>(db_pool.into())
         .insert_resource::<TaskCreator>(runtime.into())
         .add_plugin(ServerPlugin::new(configuration.game.clone(), server_id))

--- a/silkroad-agent/src/persist/comp.rs
+++ b/silkroad-agent/src/persist/comp.rs
@@ -1,0 +1,20 @@
+use bevy_ecs_macros::Component;
+use bevy_time::{Timer, TimerMode};
+use std::time::Duration;
+
+#[derive(Component)]
+pub struct Persistable {
+    time_until_next_persist: Timer,
+}
+
+impl Persistable {
+    pub fn from_seconds(seconds: u32) -> Self {
+        Self {
+            time_until_next_persist: Timer::from_seconds(seconds as f32, TimerMode::Repeating),
+        }
+    }
+
+    pub fn should_persist(&mut self, time_passed: Duration) -> bool {
+        self.time_until_next_persist.tick(time_passed).just_finished()
+    }
+}

--- a/silkroad-agent/src/persist/mod.rs
+++ b/silkroad-agent/src/persist/mod.rs
@@ -1,0 +1,17 @@
+mod comp;
+mod sys;
+
+use crate::persist::sys::{attach_persistence, run_exit_persistence, run_persistence};
+use bevy_app::{App, CoreSet, Plugin};
+use bevy_ecs::prelude::*;
+pub use comp::*;
+
+pub struct PersistencePlugin;
+
+impl Plugin for PersistencePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_system(attach_persistence.in_base_set(CoreSet::PostUpdate))
+            .add_system(run_persistence.in_base_set(CoreSet::Last))
+            .add_system(run_exit_persistence.in_base_set(CoreSet::Last));
+    }
+}

--- a/silkroad-agent/src/persist/sys.rs
+++ b/silkroad-agent/src/persist/sys.rs
@@ -1,0 +1,67 @@
+use crate::comp::player::Player;
+use crate::comp::pos::Position;
+use crate::comp::Health;
+use crate::config::GameConfig;
+use crate::db::character::CharacterData;
+use crate::event::ClientDisconnectedEvent;
+use crate::ext::DbPool;
+use crate::persist::Persistable;
+use crate::tasks::TaskCreator;
+use bevy_ecs::prelude::*;
+use bevy_ecs::query::QueryEntityError;
+use bevy_time::Time;
+use tracing::warn;
+
+pub(crate) fn attach_persistence(mut cmd: Commands, query: Query<Entity, Added<Player>>, config: Res<GameConfig>) {
+    for player_entity in query.iter() {
+        cmd.entity(player_entity)
+            .insert(Persistable::from_seconds(config.auto_save_interval));
+    }
+}
+
+pub(crate) fn run_persistence(
+    runtime: Res<TaskCreator>,
+    delta: Res<Time>,
+    db_pool: Res<DbPool>,
+    mut query: Query<(&mut Persistable, &Health, &Player, &Position)>,
+) {
+    let duration = delta.delta();
+    let mut updates: Vec<(Health, Player, Position)> = Vec::new();
+    for (mut persistable, health, player, position) in query.iter_mut() {
+        if persistable.should_persist(duration) {
+            updates.push((*health, player.clone(), *position));
+        }
+    }
+
+    let pool = db_pool.clone();
+    runtime.spawn(async move {
+        for (health, player, position) in updates.into_iter() {
+            CharacterData::update_character_info(player, health, position, &pool).await;
+        }
+    });
+}
+
+pub(crate) fn run_exit_persistence(
+    runtime: Res<TaskCreator>,
+    db_pool: Res<DbPool>,
+    query: Query<(&Health, &Player, &Position)>,
+    mut disconnect_events: EventReader<ClientDisconnectedEvent>,
+) {
+    for event in disconnect_events.iter() {
+        match query.get(event.0) {
+            Ok((health, player, position)) => {
+                let health = *health;
+                let player = player.clone();
+                let position = *position;
+                let pool = db_pool.clone();
+                runtime.spawn(async move {
+                    CharacterData::update_character_info(player, health, position, pool).await;
+                });
+            },
+            Err(QueryEntityError::NoSuchEntity(_)) => {
+                warn!("Couldn't run persistence for entity on exit as it was already removed.");
+            },
+            _ => {},
+        }
+    }
+}

--- a/silkroad-game-base/src/character.rs
+++ b/silkroad-game-base/src/character.rs
@@ -2,6 +2,7 @@ use crate::{Race, SpawningState, Stats};
 use silkroad_data::masterydata::RefMasteryData;
 use std::cmp::max;
 
+#[derive(Clone)]
 pub struct Character {
     pub id: u32,
     pub name: String,
@@ -14,8 +15,6 @@ pub struct Character {
     pub sp_exp: u32,
     pub stats: Stats,
     pub stat_points: u16,
-    pub current_hp: u32,
-    pub current_mp: u32,
     pub berserk_points: u8,
     pub gold: u64,
     pub beginner_mark: bool,

--- a/silkroad-game-base/src/stats.rs
+++ b/silkroad-game-base/src/stats.rs
@@ -1,5 +1,6 @@
 const SCALING: f32 = 1.02;
 
+#[derive(Copy, Clone)]
 pub struct Stats {
     str: u16,
     int: u16,

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,182 +1,5 @@
 {
   "db": "PostgreSQL",
-  "09a11418117d5182992d4606e13e7902c768b1ec7969094b2a92c2f061cd9bb1": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int4"
-        },
-        {
-          "name": "user_id",
-          "ordinal": 1,
-          "type_info": "Int4"
-        },
-        {
-          "name": "server_id",
-          "ordinal": 2,
-          "type_info": "Int4"
-        },
-        {
-          "name": "character_type",
-          "ordinal": 3,
-          "type_info": "Int4"
-        },
-        {
-          "name": "scale",
-          "ordinal": 4,
-          "type_info": "Int2"
-        },
-        {
-          "name": "level",
-          "ordinal": 5,
-          "type_info": "Int2"
-        },
-        {
-          "name": "exp",
-          "ordinal": 6,
-          "type_info": "Int8"
-        },
-        {
-          "name": "strength",
-          "ordinal": 7,
-          "type_info": "Int2"
-        },
-        {
-          "name": "intelligence",
-          "ordinal": 8,
-          "type_info": "Int2"
-        },
-        {
-          "name": "stat_points",
-          "ordinal": 9,
-          "type_info": "Int2"
-        },
-        {
-          "name": "current_hp",
-          "ordinal": 10,
-          "type_info": "Int4"
-        },
-        {
-          "name": "current_mp",
-          "ordinal": 11,
-          "type_info": "Int4"
-        },
-        {
-          "name": "charname",
-          "ordinal": 12,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "deletion_end",
-          "ordinal": 13,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "sp",
-          "ordinal": 14,
-          "type_info": "Int4"
-        },
-        {
-          "name": "x",
-          "ordinal": 15,
-          "type_info": "Float4"
-        },
-        {
-          "name": "y",
-          "ordinal": 16,
-          "type_info": "Float4"
-        },
-        {
-          "name": "z",
-          "ordinal": 17,
-          "type_info": "Float4"
-        },
-        {
-          "name": "max_level",
-          "ordinal": 18,
-          "type_info": "Int2"
-        },
-        {
-          "name": "region",
-          "ordinal": 19,
-          "type_info": "Int2"
-        },
-        {
-          "name": "berserk_points",
-          "ordinal": 20,
-          "type_info": "Int2"
-        },
-        {
-          "name": "gold",
-          "ordinal": 21,
-          "type_info": "Int8"
-        },
-        {
-          "name": "sp_exp",
-          "ordinal": 22,
-          "type_info": "Int4"
-        },
-        {
-          "name": "beginner_mark",
-          "ordinal": 23,
-          "type_info": "Bool"
-        },
-        {
-          "name": "gm",
-          "ordinal": 24,
-          "type_info": "Bool"
-        },
-        {
-          "name": "last_logout",
-          "ordinal": 25,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "rotation",
-          "ordinal": 26,
-          "type_info": "Int2"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Int4",
-          "Int4"
-        ]
-      }
-    },
-    "query": "SELECT * FROM characters WHERE user_id = $1 AND server_id = $2 AND (deletion_end > NOW() OR deletion_end is null) ORDER BY id ASC"
-  },
   "0cc5c4601f56468f8b198507236a3fd5ddd712b9a7e5c4eee3e711ce35d4e262": {
     "describe": {
       "columns": [],
@@ -436,6 +259,30 @@
     },
     "query": "INSERT INTO users(username, password, passcode) values($1, $2, $3)"
   },
+  "70492ab03927289ee33778287aa73009a6449567e7556b29b27fc7e8e5d44fb1": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int2",
+          "Int8",
+          "Int2",
+          "Int2",
+          "Int4",
+          "Float4",
+          "Float4",
+          "Float4",
+          "Int2",
+          "Int4",
+          "Int4",
+          "Int2",
+          "Int4"
+        ]
+      }
+    },
+    "query": "UPDATE characters SET level = $1, exp = $2, strength = $3, intelligence = $4, current_hp = $5, x = $6, y = $7, z = $8, region = $9, sp = $10, sp_exp = $11, stat_points = $12 WHERE id = $13"
+  },
   "82b58fea3da5e84ff8cff6fda5c97e7921b039d23dd8fdbb3a28c0c1da234765": {
     "describe": {
       "columns": [
@@ -570,6 +417,183 @@
       }
     },
     "query": "SELECT mastery_id, character_id, level FROM character_masteries WHERE character_id in (SELECT * FROM UNNEST($1::INTEGER[]))"
+  },
+  "c0a7577a601206fbb5bfb9919de5114916724ea0243874cff21b6b8130480e54": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int4"
+        },
+        {
+          "name": "user_id",
+          "ordinal": 1,
+          "type_info": "Int4"
+        },
+        {
+          "name": "server_id",
+          "ordinal": 2,
+          "type_info": "Int4"
+        },
+        {
+          "name": "charname",
+          "ordinal": 3,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "character_type",
+          "ordinal": 4,
+          "type_info": "Int4"
+        },
+        {
+          "name": "scale",
+          "ordinal": 5,
+          "type_info": "Int2"
+        },
+        {
+          "name": "level",
+          "ordinal": 6,
+          "type_info": "Int2"
+        },
+        {
+          "name": "max_level",
+          "ordinal": 7,
+          "type_info": "Int2"
+        },
+        {
+          "name": "exp",
+          "ordinal": 8,
+          "type_info": "Int8"
+        },
+        {
+          "name": "sp",
+          "ordinal": 9,
+          "type_info": "Int4"
+        },
+        {
+          "name": "sp_exp",
+          "ordinal": 10,
+          "type_info": "Int4"
+        },
+        {
+          "name": "strength",
+          "ordinal": 11,
+          "type_info": "Int2"
+        },
+        {
+          "name": "intelligence",
+          "ordinal": 12,
+          "type_info": "Int2"
+        },
+        {
+          "name": "stat_points",
+          "ordinal": 13,
+          "type_info": "Int2"
+        },
+        {
+          "name": "current_hp",
+          "ordinal": 14,
+          "type_info": "Int4"
+        },
+        {
+          "name": "current_mp",
+          "ordinal": 15,
+          "type_info": "Int4"
+        },
+        {
+          "name": "deletion_end",
+          "ordinal": 16,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "x",
+          "ordinal": 17,
+          "type_info": "Float4"
+        },
+        {
+          "name": "y",
+          "ordinal": 18,
+          "type_info": "Float4"
+        },
+        {
+          "name": "z",
+          "ordinal": 19,
+          "type_info": "Float4"
+        },
+        {
+          "name": "rotation",
+          "ordinal": 20,
+          "type_info": "Int2"
+        },
+        {
+          "name": "region",
+          "ordinal": 21,
+          "type_info": "Int2"
+        },
+        {
+          "name": "berserk_points",
+          "ordinal": 22,
+          "type_info": "Int2"
+        },
+        {
+          "name": "gold",
+          "ordinal": 23,
+          "type_info": "Int8"
+        },
+        {
+          "name": "beginner_mark",
+          "ordinal": 24,
+          "type_info": "Bool"
+        },
+        {
+          "name": "gm",
+          "ordinal": 25,
+          "type_info": "Bool"
+        },
+        {
+          "name": "last_logout",
+          "ordinal": 26,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Int4"
+        ]
+      }
+    },
+    "query": "SELECT id, user_id, server_id, charname, character_type, scale, level, max_level, exp, sp, sp_exp, strength, intelligence, stat_points, current_hp, current_mp, deletion_end, x, y, z, rotation, region, berserk_points, gold, beginner_mark, gm, last_logout FROM characters WHERE user_id = $1 AND server_id = $2 AND (deletion_end > NOW() OR deletion_end is null) ORDER BY id ASC"
   },
   "c8fabc599290bc2f9a95caa4b1c9eea3a78b36005a87ef1161f0bcc88c929799": {
     "describe": {


### PR DESCRIPTION
Currently, we don't save anything apart from the last login date. We should add a mechanism that will periodically synchronize the character information, such as level, masteries, items, etc.

- [ ] Attributes to persist
  - [x] Level & Experience
  - [x] SP
  - [x] Location
  - [x] Health & Mana
  - [x] Statpoints
  - [ ] Inventory
  - [ ] Masteries
- [x] Persist occasionally
- [x] Persist on logout/disconnect